### PR TITLE
ci: build from the GHCR base-image mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 
-FROM oven/bun:latest AS builder
+# Base mirrored from oven/bun into GHCR by illustrious.platform's
+# mirror-base-images.yml — pinned to :1.3 and pulled from our own registry so
+# builds don't depend on Docker Hub. The cc-mudjacking repo must have read access
+# to the ghcr.io/illustrious-online/bun package; CI logs into ghcr.io first.
+FROM ghcr.io/illustrious-online/bun:1.3 AS builder
 
 WORKDIR /app
 
@@ -16,7 +20,7 @@ ENV NEXT_PUBLIC_RECAPTCHA_SITE_KEY=$NEXT_PUBLIC_RECAPTCHA_SITE_KEY
 
 RUN bun run build
 
-FROM oven/bun:latest AS production
+FROM ghcr.io/illustrious-online/bun:1.3 AS production
 
 WORKDIR /app
 COPY --from=builder /app/.next/standalone ./


### PR DESCRIPTION
Brings cc-mudjacking onto the shared GHCR base-image mirror (per illustrious.platform), so builds don't pull the base from Docker Hub at build time.

- `Dockerfile`: `oven/bun:latest` → `ghcr.io/illustrious-online/bun:1.3` (builder + production). Also **pins** the bun version (was a moving `latest`).

## ⚠️ Requires a one-time access grant before merge
The mirror package is private and owned by `illustrious.platform`. This repo's CI `GITHUB_TOKEN` needs **read** on `ghcr.io/illustrious-online/bun`, or the release `image` build fails at `FROM`. Either:
- set the **`bun`** (and ideally **`node`**) package to **Internal** visibility (covers all org repos, future-proof), **or**
- grant the **cc-mudjacking** repo Read under the package's *Manage Actions access*.

Don't merge until that's done; the PR check (lint+tests) passes regardless since the Docker build only runs on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)